### PR TITLE
Modifications to autocompleteDirective.js - Add an mdNotFoundClick attribute to handle mdNotFound click event and feature for disabling autocomplete suggestion items

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -148,7 +148,8 @@ function MdAutocomplete () {
       floatingLabel:    '@?mdFloatingLabel',
       autoselect:       '=?mdAutoselect',
       menuClass:        '@?mdMenuClass',
-      inputId:          '@?mdInputId'
+      inputId:          '@?mdInputId',
+      notFoundClick:    '&?mdNotFoundClick'
     },
     link: function(scope, element, attrs, controller) {
       // Retrieve the state of using a md-not-found template by using our attribute, which will
@@ -194,8 +195,9 @@ function MdAutocomplete () {
                 ng-class="::menuClass"\
                 id="ul-{{$mdAutocompleteCtrl.id}}">\
               <li md-virtual-repeat="item in $mdAutocompleteCtrl.matches"\
-                  ng-class="{ selected: $index === $mdAutocompleteCtrl.index }"\
-                  ng-click="$mdAutocompleteCtrl.select($index)"\
+                  ng-class="{ selected: $index === $mdAutocompleteCtrl.index, disabled: item.is_disabled }"\
+                  ng-click="item.is_disabled || $mdAutocompleteCtrl.select($index)"\
+                  ng-disabled="item.is_disabled"\
                   md-extra-name="$mdAutocompleteCtrl.itemName">\
                   ' + itemTemplate + '\
                   </li>' + noItemsTemplate + '\
@@ -221,7 +223,10 @@ function MdAutocomplete () {
             template = templateTag.length ? templateTag.html() : '';
         return template
             ? '<li ng-if="$mdAutocompleteCtrl.notFoundVisible()"\
-                         md-autocomplete-parent-scope>' + template + '</li>'
+                    ng-click="$mdAutocompleteCtrl.notFoundClick(searchText,$event)">\
+                    <md-autocomplete-parent-scope md-autocomplete-replace>' 
+                    + template + 
+                    '</md-autocomplete-parent-scope></li>'
             : '';
 
       }


### PR DESCRIPTION
mdNotFoundClick click event handler:
- added mdNotFoundClick (md-not-found-click) scope option to handle the click event for the md-not-found template
- added li[ng-click] to handle the click event for the md-not-found template
- added <md-autocomplete-parent-scope> template wrapper to enable the click event for the md-not-found template

Disabling autocomplete suggestion items:
- modified li[ng-class] to add 'disabled' css class to control the style for disabled suggestion items
- modified li[ng-click] to disable the item selection/click event for disabled suggestion items
- added li[ng-disabled] to control the disabling of suggestion items

related commit: https://github.com/vldolot/material/commit/d5868e0342c1984cdbe1c8e1668ec7d39253718e
