### PR TITLE
Modifications to autocompleteController.js - Add an mdNotFoundClick attribute to handle mdNotFound click event 

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -52,6 +52,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   ctrl.unregisterSelectedItemWatcher = unregisterSelectedItemWatcher;
   ctrl.notFoundVisible               = notFoundVisible;
   ctrl.loadingIsVisible              = loadingIsVisible;
+  ctrl.notFoundClick                 = handleNotFoundClick;
 
   return init();
 
@@ -315,6 +316,16 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    */
   function handleSelectedItemChange (selectedItem, previousSelectedItem) {
     selectedItemWatchers.forEach(function (watcher) { watcher(selectedItem, previousSelectedItem); });
+  }
+
+  /**
+   * Handles click event for the md-not-found-click attribute.
+   * @param searchText
+   * @param previousSearchText
+   */
+  function handleNotFoundClick (searchText, previousSearchText) {
+    blur();
+    angular.isFunction($scope.notFoundClick) && $scope.notFoundClick(getItemAsNameVal($scope.selectedItem));
   }
 
   /**


### PR DESCRIPTION
mdNotFoundClick scope option:
- added handler function for the ctrl.notFoundClick scope option
- added handleNotFoundClick() function to handle the click event for the md-not-found-click attribute.

related commit: https://github.com/vldolot/material/commit/d1fa962668c964b20d002ba273bd9054c04929d4
